### PR TITLE
Fix: Properly handle parameters in AST detection to prevent errors

### DIFF
--- a/sonata/core/emotive_detector.py
+++ b/sonata/core/emotive_detector.py
@@ -484,8 +484,16 @@ class AudiosetEmotiveDetector:
             if label in self.emotion_class_mapping:
                 self.target_class_indices.append(int(i))
 
-    def detect_events(self, audio_path: str) -> List[EmotiveEvent]:
-        """Detect emotional events from audio"""
+    def detect_events(self, audio_path: str, **kwargs) -> List[EmotiveEvent]:
+        """Detect emotional events from audio
+
+        Args:
+            audio_path: Path to the audio file
+            **kwargs: Additional keyword arguments (ignored)
+
+        Returns:
+            List of detected emotive events
+        """
         if self.model is None or self.feature_extractor is None:
             logging.error("AudioSet AST model not initialized")
             return []
@@ -538,14 +546,23 @@ class AudiosetEmotiveDetector:
             return []
 
     def detect_from_array(
-        self, audio_array: np.ndarray, sr: int = 22050
+        self, audio_array: np.ndarray, sr: int = 22050, **kwargs
     ) -> List[EmotiveEvent]:
-        """Detect emotive events directly from audio array."""
+        """Detect emotive events directly from audio array.
+
+        Args:
+            audio_array: Audio samples as numpy array
+            sr: Sample rate of the audio
+            **kwargs: Additional keyword arguments (ignored)
+
+        Returns:
+            List of detected emotive events
+        """
         temp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
         temp_path = temp.name
         try:
             sf.write(temp_path, audio_array, sr)
-            return self.detect_events(temp_path)
+            return self.detect_events(audio_path=temp_path)
         finally:
             temp.close()
             if os.path.exists(temp_path):

--- a/sonata/core/transcriber.py
+++ b/sonata/core/transcriber.py
@@ -69,7 +69,7 @@ class IntegratedTranscriber:
                 batch_size=batch_size,
             )
             emotive_future = executor.submit(
-                self.emotive_detector.detect_events, audio_path
+                self.emotive_detector.detect_events, audio_path=audio_path
             )
 
             # Wait for both to complete

--- a/sonata/core/transcriber.py
+++ b/sonata/core/transcriber.py
@@ -43,6 +43,7 @@ class IntegratedTranscriber:
         audio_path: str,
         language: str = DEFAULT_LANGUAGE,
         emotive_threshold: float = EMOTIVE_THRESHOLD,
+        batch_size: int = 16,
     ) -> Dict:
         """Process audio to get transcription with emotive events integrated.
 
@@ -50,6 +51,7 @@ class IntegratedTranscriber:
             audio_path: Path to the audio file
             language: ISO language code (e.g., "en", "ko")
             emotive_threshold: Detection threshold for emotive events
+            batch_size: Batch size for ASR processing
 
         Returns:
             Dictionary containing the complete transcription results
@@ -61,7 +63,10 @@ class IntegratedTranscriber:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             # Start both tasks - pass parameters by name to avoid confusion
             asr_future = executor.submit(
-                self.asr.process_audio, audio_path=audio_path, language=language
+                self.asr.process_audio,
+                audio_path=audio_path,
+                language=language,
+                batch_size=batch_size,
             )
             emotive_future = executor.submit(
                 self.emotive_detector.detect_events, audio_path

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -197,6 +197,7 @@ def main():
                 audio_path=segment["path"],
                 language=args.language,
                 emotive_threshold=args.threshold,
+                batch_size=16,
             )
 
             # Adjust timestamps to account for segment start time
@@ -216,6 +217,7 @@ def main():
             audio_path=input_file,
             language=args.language,
             emotive_threshold=args.threshold,
+            batch_size=16,
         )
 
     # Save results

--- a/test/advanced_infer.py
+++ b/test/advanced_infer.py
@@ -68,7 +68,9 @@ def process_file(input_file, args, output_dir):
 
     # Process audio
     start_time = time.time()
-    result = transcriber.process_audio(processed_file, language=args.language)
+    result = transcriber.process_audio(
+        processed_file, language=args.language, batch_size=16
+    )
     processing_time = time.time() - start_time
 
     # Save results

--- a/test/infer.py
+++ b/test/infer.py
@@ -143,7 +143,9 @@ def main():
     )
 
     # Process audio with our wrapper that ensures batch_size is correctly used
-    result = transcriber.process_audio(audio_path=args.input, language=args.language)
+    result = transcriber.process_audio(
+        audio_path=args.input, language=args.language, batch_size=args.batch_size
+    )
 
     # Save results
     transcriber.save_result(result, args.output)


### PR DESCRIPTION
## Description
이 PR은 `ERROR:root:Error in AudioSet AST detection: '16'` 오류를 해결하는 두 번째 단계입니다.

## 연관 PR
이 PR은 #8이 먼저 병합된 후에 병합되어야 합니다. PR #8은 기본적인 batch_size 매개변수 추가를 처리하고, 이 PR은 ThreadPoolExecutor를 사용할 때 매개변수가 올바르게 처리되도록 합니다.

## Problem
batch_size 매개변수를 모든 process_audio 호출에 추가한 후에도 오류가 계속 발생했습니다. ThreadPoolExecutor를 사용할 때 한 함수 호출의 매개변수가 다른 함수로 누출되는 문제가 있었습니다.

## Changes
1. emotive_detector의 `detect_events` 및 `detect_from_array` 메서드를 **kwargs를 받도록 업데이트하여 예상치 못한 매개변수를 처리할 수 있게 함
2. transcriber.py에서 emotive_detector 메서드를 호출할 때 키워드 인수를 사용하도록 수정
3. 매개변수 처리를 문서화하기 위해 emotive detector 메서드에 적절한 docstring 추가

## Testing
이러한 변경 사항은 문자열 '16'이 예상치 못한 매개변수로 전달되는 것을 방지하여 문제를 해결합니다.