### PR TITLE
Fix duplicate batch-size argument in infer.py

### DIFF
--- a/test/infer.py
+++ b/test/infer.py
@@ -53,12 +53,6 @@ def parse_args():
         default=None,
     )
     parser.add_argument(
-        "--batch-size",
-        type=int,
-        default=16,
-        help="Batch size for ASR processing (default: 16)",
-    )
-    parser.add_argument(
         "-b",
         "--batch-size",
         type=int,


### PR DESCRIPTION
## Description
This PR fixes an error when running the inference script by removing duplicate batch-size argument in the argument parser.

## Changes Made
- Removed duplicated `--batch-size` argument in `parse_args()` function
- Kept the `-b/--batch-size` version for better usability

## Issue Fixed
Resolves the argparse error:
```
argparse.ArgumentError: argument -b/--batch-size: conflicting option string: --batch-size
```