### PR TITLE
Fix: Suppress version warning logs from WhisperX dependencies

### DIFF
--- a/sonata/core/asr.py
+++ b/sonata/core/asr.py
@@ -3,6 +3,9 @@ import numpy as np
 import torch
 import whisperx
 import ssl
+import io
+import sys
+from contextlib import redirect_stdout
 from typing import Dict, List, Union, Tuple, Optional
 from sonata.constants import LanguageCode
 
@@ -30,22 +33,26 @@ class ASRProcessor:
         """
         ssl._create_default_https_context = ssl._create_unverified_context
 
-        # Load model with explicit language parameter
-        self.model = whisperx.load_model(
-            self.model_name,
-            self.device,
-            compute_type=self.compute_type,
-            language=language_code,  # Pass language parameter directly
-        )
+        # Suppress version warnings by redirecting stdout temporarily
+        with redirect_stdout(io.StringIO()):
+            # Load model with explicit language parameter
+            self.model = whisperx.load_model(
+                self.model_name,
+                self.device,
+                compute_type=self.compute_type,
+                language=language_code,  # Pass language parameter directly
+            )
 
         # Ensure preset_language is set
         if hasattr(self.model, "preset_language"):
             self.model.preset_language = language_code
 
         try:
-            self.align_model, self.align_metadata = whisperx.load_align_model(
-                language_code=language_code, device=self.device
-            )
+            # Suppress version warnings for alignment model loading
+            with redirect_stdout(io.StringIO()):
+                self.align_model, self.align_metadata = whisperx.load_align_model(
+                    language_code=language_code, device=self.device
+                )
             self.current_language = language_code
         except Exception as e:
             print(
@@ -87,9 +94,11 @@ class ASRProcessor:
                     f"Warning: Could not load alignment model for {language}. Falling back to transcription without alignment."
                 )
                 if self.model is None:
-                    self.model = whisperx.load_model(
-                        self.model_name, self.device, compute_type=self.compute_type
-                    )
+                    # Suppress version warnings during model loading
+                    with redirect_stdout(io.StringIO()):
+                        self.model = whisperx.load_model(
+                            self.model_name, self.device, compute_type=self.compute_type
+                        )
 
         # Print parameters for debugging
         print(

--- a/sonata/core/emotive_detector.py
+++ b/sonata/core/emotive_detector.py
@@ -14,7 +14,7 @@ from sonata.constants import EMOTIVE_THRESHOLD, EmotiveEventType, EMOTIVE_CLASS_
 
 # Temporary - Set up debug logging
 logging.basicConfig(
-    level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=logging.ERROR, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 
 from dataclasses import dataclass

--- a/test/infer.py
+++ b/test/infer.py
@@ -6,6 +6,8 @@ import argparse
 import tempfile
 import wave
 import subprocess
+import io
+from contextlib import redirect_stdout
 from pathlib import Path
 from sonata.core.transcriber import IntegratedTranscriber
 from sonata.constants import (
@@ -214,7 +216,10 @@ def main():
 
     # Initialize transcriber
     print(f"Initializing transcriber with {args.model} model on {args.device}...")
-    transcriber = IntegratedTranscriber(asr_model=args.model, device=args.device)
+
+    # Suppress version warnings during initialization
+    with redirect_stdout(io.StringIO()):
+        transcriber = IntegratedTranscriber(asr_model=args.model, device=args.device)
 
     # Prepare input file - preprocessing
     processed_file = args.input
@@ -292,9 +297,13 @@ def main():
                         f"Warning: Could not load alignment model for {language}. Falling back to transcription without alignment."
                     )
                     if self.model is None:
-                        self.model = whisperx.load_model(
-                            self.model_name, self.device, compute_type=self.compute_type
-                        )
+                        # Suppress version warnings
+                        with redirect_stdout(io.StringIO()):
+                            self.model = whisperx.load_model(
+                                self.model_name,
+                                self.device,
+                                compute_type=self.compute_type,
+                            )
 
             # Transcribe with whisperx
             audio = whisperx.load_audio(audio_path)


### PR DESCRIPTION
## Description
This PR fixes the issue with verbose version warning logs shown when running the inference script by suppressing unnecessary logs from WhisperX dependencies (PyTorch Lightning, pyannote.audio, and torch).

## Changes Made
- Added `redirect_stdout` with a `StringIO` buffer to capture and discard warnings during model loading
- Applied this solution in:
  - ASRProcessor class in `sonata/core/asr.py`
  - Transcriber initialization in `test/infer.py`
  - Dynamic method addition in `test/infer.py`

## Benefits
- Cleaner console output
- No changes to actual model functionality
- Prevents unnecessary warnings from distracting users