### PR TITLE
Fix markdown links and GitHub Pages configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,59 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+          cache-version: 0
+      - name: Install dependencies
+        run: |
+          cd docs
+          gem install bundler
+          bundle init
+          bundle add jekyll github-pages webrick
+      - name: Build with Jekyll
+        run: |
+          cd docs
+          bundle exec jekyll build --baseurl "${{ github.repository }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SONATA(SOund and Narrative Advanced Transcription Assistant) is advanced ASR sys
 - ⏱️ Rich timestamp information at the word level
 - 🔄 Audio preprocessing capabilities
 
-[📚 See detailed features documentation](docs/FEATURES.md)
+[📚 See detailed features documentation](https://github.com/hwk06023/SONATA/blob/main/docs/FEATURES.md)
 
 ## 🚀 Installation
 
@@ -69,21 +69,21 @@ sonata-asr path/to/audio.wav --diarize --hf-token YOUR_HUGGINGFACE_TOKEN
 sonata-asr path/to/audio.wav --diarize --offline-diarize --offline-config ~/.sonata/models/offline_config.yaml
 ```
 
-[📚 See full usage documentation](docs/USAGE.md)  
-[⌨️ See complete CLI documentation](docs/CLI.md)  
-[🎤 See offline diarization guide](docs/OFFLINE_DIARIZATION.md)
+[📚 See full usage documentation](https://github.com/hwk06023/SONATA/blob/main/docs/USAGE.md)  
+[⌨️ See complete CLI documentation](https://github.com/hwk06023/SONATA/blob/main/docs/CLI.md)  
+[🎤 See offline diarization guide](https://github.com/hwk06023/SONATA/blob/main/docs/OFFLINE_DIARIZATION.md)
 
 ## 🗣️ Supported Languages
 
 SONATA supports 10 languages including English, Korean, Chinese, Japanese, French, German, Spanish, Italian, Portuguese, and Russian.
 
-[🌐 See languages documentation](docs/LANGUAGES.md)
+[🌐 See languages documentation](https://github.com/hwk06023/SONATA/blob/main/docs/LANGUAGES.md)
 
 ## 🔊 Audio Event Detection
 
 SONATA can detect over 500 different audio events, from laughter and applause to ambient sounds and music. The customizable event detection thresholds allow you to fine-tune sensitivity for specific audio events to match your unique use cases, such as podcast analysis, meeting transcription, or nature recording analysis.
 
-[🎵 See audio events documentation](docs/AUDIO_EVENTS.md)
+[🎵 See audio events documentation](https://github.com/hwk06023/SONATA/blob/main/docs/AUDIO_EVENTS.md)
 
 ## 🚀 Next Steps
 
@@ -96,7 +96,7 @@ SONATA can detect over 500 different audio events, from laughter and applause to
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
-[📝 See contribution guidelines](docs/CONTRIBUTING.md)
+[📝 See contribution guidelines](https://github.com/hwk06023/SONATA/blob/main/docs/CONTRIBUTING.md)
 
 ## 📄 License
 

--- a/docs/AUDIO_EVENTS.md
+++ b/docs/AUDIO_EVENTS.md
@@ -9,18 +9,11 @@ permalink: /AUDIO_EVENTS
 
 SONATA includes advanced audio event detection capabilities that can identify over 500 different types of sounds in your audio files.
 
-## Supported Audio Events
+## Full List of Supported Audio Events
 
-SONATA can detect a wide range of audio events, including:
+SONATA can detect over 523 different audio event types, grouped into categories including human sounds, animal sounds, music, natural sounds, and more.
 
-- Human sounds (laughter, crying, coughing, etc.)
-- Animal sounds (barks, meows, bird calls, etc.)
-- Musical sounds (instruments, singing, etc.)
-- Environmental sounds (wind, rain, thunder, etc.)
-- Mechanical sounds (engines, vehicles, alarms, etc.)
-- Domestic sounds (doors, typing, microwave, etc.)
-
-For a complete list of detectable audio events, see the [`AudioEventType` enum in constants.py](../sonata/constants.py).
+For a complete list of detectable audio events, see the [`AudioEventType` enum in constants.py`](https://github.com/hwk06023/SONATA/blob/main/sonata/constants.py).
 
 ## Detection Sensitivity
 
@@ -97,4 +90,4 @@ Custom thresholds can be particularly useful in scenarios like:
 - **Nature Recordings**: Customize thresholds for specific bird or animal sounds
 - **Music Analysis**: Fine-tune detection of specific instruments or musical elements
 
-For a complete example of using custom thresholds, see the [custom_thresholds_example.py](../test/custom_thresholds_example.py) script. 
+For a complete example of using custom thresholds, see the [custom_thresholds_example.py](https://github.com/hwk06023/SONATA/blob/main/test/custom_thresholds_example.py) script. 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -19,27 +19,11 @@ SONATA uses WhisperX, an enhanced version of Whisper that provides:
 - Automatic language detection capabilities
 - Model optimization for various hardware (CPU, CUDA, MPS)
 
-## 😀 Audio Event Detection
+## Advanced Audio Event Detection
 
-SONATA can detect 523+ distinct audio events using the AudioSet AST (Audio Spectrogram Transformer) model, including:
+SONATA identifies non-speech sounds - from laughter and crying to ambient noises like traffic or music. Our system can detect over 523 different audio events with precise confidence scoring.
 
-### Human Sounds
-- Laughter, crying, sighing, whispering, screaming, shouting
-- Conversation, narration, male/female/child speech
-- Breathing, coughing, sneezing, sniffing, throat clearing
-
-### Physical Sounds
-- Clapping, finger snapping, footsteps, heartbeat
-- Hands, applause, cheering
-
-### Animal Sounds
-- Dog barking, cat meowing, bird calls
-- Various other animal vocalizations
-
-### Musical and Environmental Sounds
-- Musical instruments (piano, guitar, drum, violin)
-- Natural sounds (wind, rain, thunder, water, fire)
-- Mechanical sounds (engines, vehicles, alarms)
+[🔊 See complete list of detectable audio events](https://github.com/hwk06023/SONATA/blob/main/docs/AUDIO_EVENTS.md)
 
 ## 🌍 Multi-Language Support
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,6 +32,16 @@ footer_content: "Copyright &copy; 2024 SONATA. Distributed under GPLv3 license."
 # Color scheme
 color_scheme: light
 
+# Markdown settings
+markdown: kramdown
+kramdown:
+  syntax_highlighter_opts:
+    block:
+      line_numbers: false
+
+# Enable proper page permalinks
+permalink: pretty
+
 # Google Analytics
 ga_tracking: 
 ga_tracking_anonymize_ip: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,8 +69,8 @@ sonata-asr path/to/audio.wav --diarize --hf-token YOUR_HUGGINGFACE_TOKEN
 
 ## Documentation
 
-- [Features](./FEATURES.html)
-- [Usage Guide](./USAGE.html)
-- [CLI Reference](./CLI.html)
-- [Audio Event Detection](./AUDIO_EVENTS.html)
-- [Offline Diarization](./OFFLINE_DIARIZATION.html) 
+- [Features](https://github.com/hwk06023/SONATA/blob/main/docs/FEATURES.md)
+- [Usage Guide](https://github.com/hwk06023/SONATA/blob/main/docs/USAGE.md)
+- [CLI Reference](https://github.com/hwk06023/SONATA/blob/main/docs/CLI.md)
+- [Audio Event Detection](https://github.com/hwk06023/SONATA/blob/main/docs/AUDIO_EVENTS.md)
+- [Offline Diarization](https://github.com/hwk06023/SONATA/blob/main/docs/OFFLINE_DIARIZATION.md) 


### PR DESCRIPTION
## Changes
- Updated all markdown file links from relative paths to absolute GitHub URLs
- Added proper GitHub Pages configuration
- Set up GitHub Pages workflow for automatic site building
- Fixed kramdown configuration for proper markdown rendering

This PR fixes navigation between markdown files to use direct GitHub links and improves GitHub Pages configuration to properly render markdown content.