### PR TITLE
Add --format option for formatted transcript output

### DIFF
--- a/sonata/core/transcriber.py
+++ b/sonata/core/transcriber.py
@@ -467,8 +467,9 @@ class IntegratedTranscriber:
 
         # Concise format: all text in one line with speaker markers and audio events
         if format_type == "concise":
-            output = []
+            formatted_lines = []
             current_speaker = None
+            current_line = []
             all_items = []
 
             # Combine words and audio events and sort by time
@@ -498,15 +499,26 @@ class IntegratedTranscriber:
             # Process all items in time order
             for item in all_items:
                 if item["type"] == "word":
+                    # If speaker changes, start a new line
                     if item["speaker"] != current_speaker:
+                        # Add current line to output if it exists
+                        if current_line:
+                            formatted_lines.append(" ".join(current_line))
+                            current_line = []
+
                         current_speaker = item["speaker"]
                         if current_speaker:
-                            output.append(f"[{current_speaker}]")
-                    output.append(item["content"])
-                else:  # audio event
-                    output.append(f"[{item['content']}]")
+                            current_line.append(f"[{current_speaker}]")
 
-            return " ".join(output)
+                    current_line.append(item["content"])
+                else:  # audio event
+                    current_line.append(f"[{item['content']}]")
+
+            # Add the last line if it exists
+            if current_line:
+                formatted_lines.append(" ".join(current_line))
+
+            return "\n".join(formatted_lines)
 
         # Default format: Group by speaker with timestamps
         elif format_type == "default":

--- a/sonata/core/transcriber.py
+++ b/sonata/core/transcriber.py
@@ -425,8 +425,8 @@ class IntegratedTranscriber:
         Args:
             result: The transcription result
             format_type: The format type ('concise', 'default', or 'extended')
-                - concise: Text with integrated audio event tags
-                - default: Text with timestamps for each word (one word per line)
+                - concise: Text with speaker markers and audio event tags in one line
+                - default: Text grouped by speaker with timestamps
                 - extended: Default format with confidence scores
 
         Returns:
@@ -434,12 +434,6 @@ class IntegratedTranscriber:
         """
         if not result or "integrated_transcript" not in result:
             return "No transcript available."
-
-        transcript_data = result["integrated_transcript"]
-        rich_text = transcript_data.get("rich_text", [])
-
-        if not rich_text:
-            return transcript_data.get("plain_text", "No transcript available.")
 
         # Get word timestamps from the segments
         word_timestamps = []
@@ -451,46 +445,75 @@ class IntegratedTranscriber:
                         "start": word.get("start", 0),
                         "end": word.get("end", 0),
                         "speaker": word.get("speaker", None),
+                        "confidence": word.get("confidence", 0.5),
                     }
                     word_timestamps.append(word_data)
 
-        # Concise format: simple text with audio event tags integrated
+        # Get audio events
+        audio_events = []
+        for event in result.get("audio_events", []):
+            audio_events.append(
+                {
+                    "type": event.get("type", "unknown"),
+                    "start": event.get("start", 0),
+                    "end": event.get("end", 0),
+                    "confidence": event.get("confidence", 0.5),
+                }
+            )
+
+        # Sort all items by start time
+        word_timestamps.sort(key=lambda x: x["start"])
+        audio_events.sort(key=lambda x: x["start"])
+
+        # Concise format: all text in one line with speaker markers and audio events
         if format_type == "concise":
-            text_parts = []
+            output = []
             current_speaker = None
+            all_items = []
 
-            for item in rich_text:
-                content = item["content"]
-                speaker = item.get("speaker")
-                audio_events = item.get("audio_events", [])
+            # Combine words and audio events and sort by time
+            for word in word_timestamps:
+                all_items.append(
+                    {
+                        "type": "word",
+                        "content": word["word"],
+                        "start": word["start"],
+                        "end": word["end"],
+                        "speaker": word["speaker"],
+                    }
+                )
 
-                # Handle speaker changes
-                if speaker != current_speaker:
-                    if (
-                        text_parts and current_speaker
-                    ):  # Add a line break between speakers
-                        text_parts.append("")
-                    current_speaker = speaker
-                    if speaker:
-                        text_parts.append(f"[{speaker}]")
+            for event in audio_events:
+                all_items.append(
+                    {
+                        "type": "audio",
+                        "content": event["type"],
+                        "start": event["start"],
+                        "end": event["end"],
+                    }
+                )
 
-                # Add content with audio events
-                if audio_events:
-                    event_tags = " ".join([f"[{event}]" for event in audio_events])
-                    text_parts.append(f"{content} {event_tags}")
-                else:
-                    text_parts.append(content)
+            all_items.sort(key=lambda x: x["start"])
 
-            return "\n".join(text_parts)
+            # Process all items in time order
+            for item in all_items:
+                if item["type"] == "word":
+                    if item["speaker"] != current_speaker:
+                        current_speaker = item["speaker"]
+                        if current_speaker:
+                            output.append(f"[{current_speaker}]")
+                    output.append(item["content"])
+                else:  # audio event
+                    output.append(f"[{item['content']}]")
 
-        # Default format: with timestamps for each word
+            return " ".join(output)
+
+        # Default format: Group by speaker with timestamps
         elif format_type == "default":
             formatted_lines = []
             current_speaker = None
 
-            # Sort word timestamps by start time
-            word_timestamps.sort(key=lambda x: x["start"])
-
+            # Process words grouped by speaker
             for word in word_timestamps:
                 start_time = self._format_time(word["start"])
                 content = word["word"]
@@ -502,16 +525,19 @@ class IntegratedTranscriber:
                         formatted_lines.append("")
                     current_speaker = speaker
                     if speaker:
-                        formatted_lines.append(f"[{start_time}] [{speaker}]")
+                        formatted_lines.append(f"[{speaker}]")
 
                 # Add word with timestamp
                 formatted_lines.append(f"[{start_time}] {content}")
 
-            # Add audio events on separate lines
-            for item in rich_text:
-                for event in item.get("audio_events", []):
-                    start_time = self._format_time(item.get("start", 0))
-                    formatted_lines.append(f"[{start_time}] [{event}]")
+            # Add audio events under [AUDIO] section
+            if audio_events:
+                if formatted_lines:
+                    formatted_lines.append("")
+                formatted_lines.append("[AUDIO]")
+                for event in audio_events:
+                    start_time = self._format_time(event["start"])
+                    formatted_lines.append(f"[{start_time}] [{event['type']}]")
 
             return "\n".join(formatted_lines)
 
@@ -520,16 +546,12 @@ class IntegratedTranscriber:
             formatted_lines = []
             current_speaker = None
 
-            # Sort word timestamps by start time
-            word_timestamps.sort(key=lambda x: x["start"])
-
+            # Process words grouped by speaker with confidence scores
             for word in word_timestamps:
                 start_time = self._format_time(word["start"])
                 content = word["word"]
                 speaker = word.get("speaker")
-                confidence = word.get(
-                    "confidence", 0.9
-                )  # Default confidence if not provided
+                confidence = word.get("confidence", 0.5)
                 confidence_str = (
                     f"{confidence:.2f}" if isinstance(confidence, float) else confidence
                 )
@@ -540,19 +562,28 @@ class IntegratedTranscriber:
                         formatted_lines.append("")
                     current_speaker = speaker
                     if speaker:
-                        formatted_lines.append(f"[{start_time}] [{speaker}]")
+                        formatted_lines.append(f"[{speaker}]")
 
                 # Add word with timestamp and confidence
                 formatted_lines.append(
                     f"[{start_time}] {content} (confidence: {confidence_str})"
                 )
 
-            # Add audio events on separate lines with confidence
-            for item in rich_text:
-                for event in item.get("audio_events", []):
-                    start_time = self._format_time(item.get("start", 0))
+            # Add audio events under [AUDIO] section with confidence
+            if audio_events:
+                if formatted_lines:
+                    formatted_lines.append("")
+                formatted_lines.append("[AUDIO]")
+                for event in audio_events:
+                    start_time = self._format_time(event["start"])
+                    confidence = event.get("confidence", 0.5)
+                    confidence_str = (
+                        f"{confidence:.2f}"
+                        if isinstance(confidence, float)
+                        else confidence
+                    )
                     formatted_lines.append(
-                        f"[{start_time}] [{event}] (confidence: 0.85)"
+                        f"[{start_time}] [{event['type']}] (confidence: {confidence_str})"
                     )
 
             return "\n".join(formatted_lines)

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -307,7 +307,7 @@ def process_file(transcriber, input_path, output_path, args):
 
     # For --format option, use a different filename
     if args.format:
-        text_output = f"{base_name}_formatted.txt"
+        text_output = f"formatted_{base_name}.txt"
 
     # Handle splitting if requested
     if args.split:

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -307,7 +307,7 @@ def process_file(transcriber, input_path, output_path, args):
 
     # For --format option, use a different filename
     if args.format:
-        text_output = f"formatted_{base_name}.txt"
+        text_output = f"{base_name}_formatted.txt"
 
     # Handle splitting if requested
     if args.split:

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -67,6 +67,13 @@ def parse_args():
         help="Save formatted transcript to text file (default: input_name.txt)",
     )
     parser.add_argument(
+        "--format",
+        nargs="?",
+        const=FORMAT_DEFAULT,
+        choices=[FORMAT_CONCISE, FORMAT_DEFAULT, FORMAT_EXTENDED],
+        help=f"Save formatted transcript with specified format (default: {FORMAT_DEFAULT})",
+    )
+    parser.add_argument(
         "--preprocess",
         action="store_true",
         help="Preprocess audio (convert format and trim silence)",
@@ -156,6 +163,9 @@ def show_usage_and_exit():
         "  --text-output            Save transcript to text file (defaults to input_name.txt)"
     )
     print(
+        "  --format [TYPE]          Save formatted transcript (concise, default, extended)"
+    )
+    print(
         "  --diarize               Enable speaker diarization to identify different speakers"
     )
     print("\nDiarization options:")
@@ -167,6 +177,7 @@ def show_usage_and_exit():
     print("  sonata-asr input.wav -o transcript.json")
     print("  sonata-asr input.wav -d cuda --preprocess")
     print("  sonata-asr input.wav --text-output")
+    print("  sonata-asr input.wav --format concise")
     print("  sonata-asr input.wav --diarize")
     print("  sonata-asr input.wav --diarize --num-speakers 3")
     sys.exit(1)
@@ -294,6 +305,10 @@ def process_file(transcriber, input_path, output_path, args):
     base_name = os.path.splitext(output_path)[0]
     text_output = f"{base_name}.txt"
 
+    # For --format option, use a different filename
+    if args.format:
+        text_output = f"{base_name}_formatted.txt"
+
     # Handle splitting if requested
     if args.split:
         print(f"Splitting audio into {args.split_length}s segments...")
@@ -338,6 +353,15 @@ def process_file(transcriber, input_path, output_path, args):
                 f.write(text_content)
             print(f"Formatted transcript saved to: {text_output}")
 
+        # Save formatted text if requested
+        if args.format:
+            formatted_text = transcriber.get_formatted_transcript(
+                merged_result, args.format
+            )
+            with open(text_output, "w", encoding="utf-8") as f:
+                f.write(formatted_text)
+            print(f"Formatted transcript saved to: {text_output}")
+
         print(f"Merged transcript saved to: {output_path}")
     else:
         # Process the entire file
@@ -358,6 +382,13 @@ def process_file(transcriber, input_path, output_path, args):
             text_content = transcriber.get_plain_transcript(result)
             with open(text_output, "w", encoding="utf-8") as f:
                 f.write(text_content)
+            print(f"Formatted transcript saved to: {text_output}")
+
+        # Save formatted text if requested
+        if args.format:
+            formatted_text = transcriber.get_formatted_transcript(result, args.format)
+            with open(text_output, "w", encoding="utf-8") as f:
+                f.write(formatted_text)
             print(f"Formatted transcript saved to: {text_output}")
 
 


### PR DESCRIPTION
This PR adds a new `--format` option to allow users to save formatted transcripts with different formatting styles:

- `--format concise`: Outputs speech in a single line with speaker annotations and audio events
- `--format default` (or just `--format`): Groups text by speaker with timestamps
- `--format extended`: Includes confidence scores along with speaker groups and timestamps

When using the `--format` option, the output is saved to a file with `_formatted.txt` suffix to differentiate it from the regular `--text-output` file.

This enhances the flexibility of the text output formats while maintaining compatibility with existing functionality.